### PR TITLE
Wrap annotations

### DIFF
--- a/assets/xml/WSI.IntelliJ.xml
+++ b/assets/xml/WSI.IntelliJ.xml
@@ -29,8 +29,6 @@
     <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
     <option name="TERNARY_OPERATION_WRAP" value="5" />
     <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="CLASS_ANNOTATION_WRAP" value="1" />
-    <option name="FIELD_ANNOTATION_WRAP" value="0" />
     <option name="ENUM_CONSTANTS_WRAP" value="1" />
     <indentOptions>
       <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/assets/xml/WSI.IntelliJ.xml
+++ b/assets/xml/WSI.IntelliJ.xml
@@ -1,4 +1,7 @@
 <code_scheme name="WSI" version="173">
+  <JavaCodeStyleSettings>
+    <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
+  </JavaCodeStyleSettings>
   <codeStyleSettings language="JAVA">
     <option name="KEEP_LINE_BREAKS" value="false" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />


### PR DESCRIPTION
I think we should add a line wrap after annotations - both because it's easier to read and produces cleaner Git diffs. I configured IntelliJ per screenshot below and exported the settings. I was a bit surprised that this removes the options but I guess that's what it is. ¯\\_(ツ)_/¯

<img width="347" alt="Screenshot 2021-12-21 at 14 36 00" src="https://user-images.githubusercontent.com/13346/146939079-5c924203-92bd-4dde-95ee-f81409fb593f.png">
